### PR TITLE
allow filtering tables

### DIFF
--- a/cfn/dynamodb-autoscale-notifier.cfn.json
+++ b/cfn/dynamodb-autoscale-notifier.cfn.json
@@ -20,6 +20,14 @@
                   "SlackApiKey",
                   "SlackChannel"
                ]
+            },
+            {
+               "Label":{
+                  "default":"DynamoDB Notifier"
+               },
+               "Parameters":[
+                  "TableFilter"
+               ]
             }
          ]
       }
@@ -44,6 +52,11 @@
          "Type":"String",
          "Default":"#general",
          "Description":"Slack Channel to post scaling notifications to"
+      },
+      "TableFilter":{
+         "Type":"String",
+         "Default":"",
+         "Description":"Only post scaling notifications for tables that match the table filter regular expression"
       }
    },
    "Resources":{
@@ -111,6 +124,17 @@
                   },
                   "slack_channel":{
                      "Ref":"SlackChannel"
+                  },
+                  "table_filter": {
+                     "Fn::If": [
+                        "HasTableFilter",
+                        {
+                           "Ref": "TableFilter"
+                        },
+                        {
+                           "Ref": "AWS::NoValue"
+                        }
+                     ]
                   }
                }
             },
@@ -174,6 +198,20 @@
                ]
             }
          }
+      }
+   },
+   "Conditions": {
+      "HasTableFilter": {
+         "Fn::Not": [
+            {
+               "Fn::Equals": [
+                  "",
+                  {
+                     "Ref": "TableFilter"
+                  }
+               ]
+            }
+         ]
       }
    }
 }

--- a/lambda/dynamodb-as-notify-slack.py
+++ b/lambda/dynamodb-as-notify-slack.py
@@ -1,5 +1,6 @@
 import json
-import sys,os
+import os
+import re
 from slacker import Slacker
 
 def send_to_slack(message,channel,key):
@@ -43,6 +44,10 @@ def lambda_handler(event, context):
             region=event['region']
             event_name=event['detail']['eventName']
             table_name = event['detail']['requestParameters']['tableName']
+
+            if 'table_filter' in os.environ and re.match(os.environ['table_filter'], table_name) is None:
+                print "Table filtered: " + table_name
+                return status
 
             if 'globalSecondaryIndexUpdates' in event['detail']['requestParameters']:
                 # We are updating an index - find out which one


### PR DESCRIPTION
Allow only sending notification for certain tables (such as tables starting with a certain prefix)

After short read of the AWS documentation there seems no easy way to only get events for certain tables (it would require listing each table explicitly).

Instead I added the possibility to filter the message inside the lambda function 